### PR TITLE
Betting Round Flow

### DIFF
--- a/ai/weak-bot.js
+++ b/ai/weak-bot.js
@@ -1,5 +1,6 @@
 const rx = require('rx');
 const uuid = require('uuid');
+const _ = require('underscore-plus');
 
 module.exports =
 class WeakBot {
@@ -13,7 +14,7 @@ class WeakBot {
 
   // LOL WEAK
   getAction(previousActions) {
-    let action = previousActions.indexOf('bet') > -1 ? 'fold' : 'check';
+    let action = _.values(previousActions).indexOf('bet') > -1 ? 'fold' : 'check';
     return rx.Observable.timer(500).map(() => action);
   }
 };

--- a/src/player-interaction.js
+++ b/src/player-interaction.js
@@ -1,4 +1,5 @@
 const rx = require('rx');
+const _ = require('underscore-plus');
 
 class PlayerInteraction {
   // Public: Poll players that want to join the game during a specified period
@@ -116,14 +117,15 @@ class PlayerInteraction {
   // Private: Given an array of actions taken previously in the hand, returns
   // an array of available actions.
   //
-  // previousActions - An array of the previous player actions for this round
+  // previousActions - A map of players to their most recent action
   //
   // Returns an array of strings
   static getAvailableActions(previousActions) {
+    let actions = _.values(previousActions);
     let availableActions = [];
 
     // NB: If a bet has been made, call and raise are available.
-    if (previousActions.indexOf('bet') > -1) {
+    if (actions.indexOf('bet') > -1) {
       availableActions.push('call');
       availableActions.push('raise');
     } else {

--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -41,7 +41,8 @@ class TexasHoldem {
     this.dealerButton = Math.floor(Math.random() * this.players.length);
 
     return rx.Observable.return(true)
-      .flatMap(() => this.playHand())
+      .flatMap(() => this.playHand()
+        .flatMap(() => rx.Observable.timer(5000)))
       .repeat()
       .takeUntil(this.quitGame)
       .subscribe();
@@ -90,6 +91,9 @@ class TexasHoldem {
   // Returns an {Observable} signaling the completion of the round
   doBettingRound(round) {
     this.orderedPlayers = PlayerOrder.determine(this.players, this.dealerButton, round);
+    for (let player of this.orderedPlayers) {
+      player.lastAction = null;
+    }
 
     let previousActions = {};
     let roundEnded = new rx.Subject();

--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -86,6 +86,7 @@ class TexasHoldem {
       this.channel.send(message);
       this.dealerButton = (this.dealerButton + 1) % this.players.length;
       handEnded.onNext(true);
+      handEnded.onCompleted();
     };
 
     let flop = () => {

--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -83,10 +83,12 @@ class TexasHoldem {
         this.dealerButton = (this.dealerButton + 1) % this.players.length;
       });
 
-    return this.doBettingRound('preflop').flatMap(() =>
+    let hand = this.doBettingRound('preflop').flatMap(() =>
       this.flop().flatMap(() =>
         this.turn().flatMap(() =>
           this.river().flatMap(handFinished))));
+
+    return hand.takeUntil(this.handEnded);
   }
 
   // Private: Handles the logic for a round of betting.
@@ -102,16 +104,45 @@ class TexasHoldem {
     // NB: Take the players remaining in the hand, in order, and map each to an
     // action for that round. We use `reduce` to turn the resulting sequence
     // into a single array.
-    return rx.Observable.fromArray(this.orderedPlayers)
+    let cycle = rx.Observable.fromArray(this.orderedPlayers)
       .where((player) => player.isInHand)
       .concatMap((player) => this.deferredActionForPlayer(player, previousActions))
-      .repeat()
       .reduce((acc, x) => {
-        console.log(`${x.player.name} ${x.action}s`);
+        this.onPlayerAction(x.player, x.action);
         acc.push(x);
         return acc;
       }, [])
-      .takeUntil(this.roundEnded);
+      .do((results) => {
+        console.log(results.length);
+        this.roundEnded.onNext(false);
+      });
+
+    let ret = this.roundEnded.flatMap((ended) => {
+      if (!ended) return cycle;
+      else return rx.Observable.return(ended);
+    }).publish();
+    
+    ret.connect();
+    this.roundEnded.onNext(false);
+    return ret;
+  }
+
+  onPlayerAction(player, action) {
+    console.log(`${player.name} ${action}s`);
+
+    if (action === 'fold') {
+      player.isInHand = false;
+
+      let playersRemaining = _.filter(this.players, (player) => player.isInHand);
+
+      if (playersRemaining.length === 1) {
+        let result = { winner: playersRemaining[0] };
+        console.log(`Hand ended, ${result.winner.name} wins`);
+
+        this.roundEnded.onNext(true);
+        this.handEnded.onNext(result);
+      }
+    }
   }
 
   // Private: Displays player position and who's next to act, pauses briefly,
@@ -131,35 +162,12 @@ class TexasHoldem {
 
       return rx.Observable.timer(timeToPause).flatMap(() =>
         PlayerInteraction.getActionForPlayer(this.messages, this.channel, player, previousActions)
-          .map((action) => this.onPlayerAction(player, action, previousActions)));
+          .map((action) => {
+            player.lastAction = action;
+            previousActions[player] = action;
+            return {player: player, action: action};
+          }));
     });
-  }
-
-  // Private: Occurs after a player takes an action. We need to save that
-  // action, and possibly end the hand if only one player is left.
-  //
-  // player - The player who acted
-  // action - A string describing the action, e.g., 'check', 'fold'
-  // previousActions - A map of players to their most recent action
-  //
-  // Returns nothing
-  onPlayerAction(player, action, previousActions) {
-    player.lastAction = action;
-    previousActions[player] = action;
-
-    if (action === 'fold') {
-      player.isInHand = false;
-
-      let playersRemaining = _.filter(this.players, (player) => player.isInHand);
-
-      if (playersRemaining.length === 1) {
-        let result = { winner: playersRemaining[0] };
-        console.log(`Hand ended, ${result.winner.name} wins`);
-
-        this.roundEnded.onNext(result);
-      }
-    }
-    return {player: player, action: action};
   }
 
   // Private: Adds players to the hand if they have enough chips and posts

--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -83,83 +83,34 @@ class TexasHoldem {
     return handEnded;
   }
 
-  flop(handEnded) {
-    let flop = [this.deck.drawCard(), this.deck.drawCard(), this.deck.drawCard()];
-    this.board = flop;
-
-    this.postBoard('flop').subscribe(() =>
-      this.doBettingRound('flop').subscribe((result) =>
-        result.isHandComplete ?
-          this.endHand(handEnded, result) :
-          this.turn(handEnded)));
-  }
-
-  turn(handEnded) {
-    this.deck.drawCard(); // Burn one
-    let turn = this.deck.drawCard();
-    this.board.push(turn);
-
-    this.postBoard('turn').subscribe(() =>
-      this.doBettingRound('turn').subscribe((result) =>
-        result.isHandComplete ?
-          this.endHand(handEnded, result) :
-          this.river(handEnded)));
-  }
-
-  river(handEnded) {
-    this.deck.drawCard(); // Burn one
-    let river = this.deck.drawCard();
-    this.board.push(river);
-
-    this.postBoard('river').subscribe(() =>
-      this.doBettingRound('river').subscribe((result) => {
-        // Still no winner? Time for the showdown.
-        if (!result.isHandComplete) {
-          result = this.evaluateHands();
-        }
-        this.endHand(handEnded, result);
-      }));
-  }
-
-  endHand(handEnded, result) {
-    let message = `${result.winner.name} wins`;
-    if (result.hand) {
-      message += ` with ${result.handName}, ${result.hand.toString()}`;
-    }
-    this.channel.send(message);
-    this.dealerButton = (this.dealerButton + 1) % this.players.length;
-
-    handEnded.onNext(true);
-    handEnded.onCompleted();
-  }
-
   // Private: Handles the logic for a round of betting.
   //
   // round - The name of the betting round, e.g., 'preflop', 'flop', 'turn'
   //
-  // Returns an array of actions taken during the round
+  // Returns an {Observable} signaling the completion of the round
   doBettingRound(round) {
-    this.roundEnded = new rx.Subject();
     this.orderedPlayers = PlayerOrder.determine(this.players, this.dealerButton, round);
-    let previousActions = {};
 
-    // NB: Take the players remaining in the hand, in order, and map each to an
-    // action for that round. We use `reduce` to turn the resulting sequence
-    // into a single array.
+    let previousActions = {};
+    let roundEnded = new rx.Subject();
+
+    // NB: Take the players remaining in the hand, in order, and poll each for
+    // an action. This cycle will be repeated until the round is ended, which
+    // can occur after any player action.
     let queryPlayers = rx.Observable.fromArray(this.orderedPlayers)
       .where((player) => player.isInHand)
       .concatMap((player) => this.deferredActionForPlayer(player, previousActions))
       .repeat()
       .reduce((acc, x) => {
-        this.onPlayerAction(x.player, x.action, acc);
+        this.onPlayerAction(x.player, x.action, acc, roundEnded);
         acc.push(x);
         return acc;
       }, [])
-      .takeUntil(this.roundEnded)
+      .takeUntil(roundEnded)
       .publish();
 
     queryPlayers.connect();
-    return this.roundEnded;
+    return roundEnded;
   }
 
   // Private: Displays player position and who's next to act, pauses briefly,
@@ -187,7 +138,17 @@ class TexasHoldem {
     });
   }
 
-  onPlayerAction(player, action, previousActions) {
+  // Private: Occurs when a player action is received. Check the remaining
+  // players and the previous actions, and possibly end the round of betting or
+  // the hand entirely.
+  //
+  // player - The player who acted
+  // action - The action the player took
+  // previousActions - A map of players to their most recent action
+  // roundEnded - A {Subject} used to end the betting round
+  //
+  // Returns nothing
+  onPlayerAction(player, action, previousActions, roundEnded) {
     console.log(`${previousActions.length}: ${player.name} ${action}s`);
 
     if (action === 'fold') {
@@ -197,18 +158,99 @@ class TexasHoldem {
 
       if (playersRemaining.length === 1) {
         let result = { isHandComplete: true, winner: playersRemaining[0] };
-        this.roundEnded.onNext(result);
+        roundEnded.onNext(result);
       }
     } else if (action === 'check') {
       let everyoneChecked = _.every(previousActions, (x) => x.action === 'check');
       let playersRemaining = _.filter(this.players, (player) => player.isInHand);
       let everyoneHadATurn = (previousActions.length + 1) % playersRemaining.length === 0;
 
+      // TODO: Naive logic, we need to actually check that everyone has called
+      // the bettor
       if (everyoneChecked && everyoneHadATurn) {
         let result = { isHandComplete: false };
-        this.roundEnded.onNext(result);
+        roundEnded.onNext(result);
       }
     }
+  }
+
+  // Private: Displays the flop cards and does a round of betting. If the
+  // betting round results in a winner, end the hand prematurely. Otherwise,
+  // progress to the turn.
+  //
+  // handEnded - A {Subject} that is used to end the hand
+  //
+  // Returns nothing
+  flop(handEnded) {
+    this.deck.drawCard(); // Burn one
+    let flop = [this.deck.drawCard(), this.deck.drawCard(), this.deck.drawCard()];
+    this.board = flop;
+
+    this.postBoard('flop').subscribe(() =>
+      this.doBettingRound('flop').subscribe((result) =>
+        result.isHandComplete ?
+          this.endHand(handEnded, result) :
+          this.turn(handEnded)));
+  }
+
+  // Private: Displays the turn card and does an additional round of betting.
+  //
+  // handEnded - A {Subject} that is used to end the hand
+  //
+  // Returns nothing
+  turn(handEnded) {
+    this.deck.drawCard(); // Burn one
+    let turn = this.deck.drawCard();
+    this.board.push(turn);
+
+    this.postBoard('turn').subscribe(() =>
+      this.doBettingRound('turn').subscribe((result) =>
+        result.isHandComplete ?
+          this.endHand(handEnded, result) :
+          this.river(handEnded)));
+  }
+
+  // Private: Displays the river card and does a final round of betting.
+  //
+  // handEnded - A {Subject} that is used to end the hand
+  //
+  // Returns nothing
+  river(handEnded) {
+    this.deck.drawCard(); // Burn one
+    let river = this.deck.drawCard();
+    this.board.push(river);
+
+    this.postBoard('river').subscribe(() =>
+      this.doBettingRound('river').subscribe((result) => {
+        // Still no winner? Time for a showdown.
+        if (!result.isHandComplete) {
+          result = this.evaluateHands();
+        }
+        this.endHand(handEnded, result);
+      }));
+  }
+
+  // Private: Does work after the hand, including declaring a winner, giving
+  // them chips, and moving the dealer button.
+  //
+  // handEnded - A {Subject} that is used to end the hand
+  // result - An object with keys for the winning player and (optionally) the
+  //          hand, if a showdown was required
+  //
+  // Returns nothing
+  endHand(handEnded, result) {
+    let message = `${result.winner.name} wins`;
+    if (result.hand) {
+      message += ` with ${result.handName}, ${result.hand.toString()}.`;
+    } else {
+      message += ".";
+    }
+
+    this.channel.send(message);
+    this.dealerButton = (this.dealerButton + 1) % this.players.length;
+
+    handEnded.onNext(true);
+    handEnded.onCompleted();
   }
 
   // Private: Adds players to the hand if they have enough chips and posts


### PR DESCRIPTION
This PR reworks the flow of both a hand and a betting round, allowing for hands to be ended prematurely and for betting rounds to cycle through players multiple times.

1. Rather than flattening the entire hand into a single `Observable`, it's now split into distinct sections, with the option to end the hand after each round of betting.
2. There are now `roundEnded` and `handEnded` subjects.
3. `repeat` and `takeUntil` are used in combination to repeat cycles.