### PR TITLE
Add Heroku button for one-click deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ See it [in action](http://cl.ly/2G3D0B24201O).
 1. To start a game, `@<your_bot_name>: Deal`
 1. To end a game, `@<your_bot_name>: Quit game`
 
-### HEROKU Getting Started
+#### Heroku
 
-#### For the lazy:
+##### For the lazy:
 Click this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-#### Manually:
+##### Manually:
 1. Install [Heroku toolbelt](https://devcenter.heroku.com/articles/getting-started-with-nodejs#set-up)
 1. Create new bot integration (as above)
 1. `heroku create`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ See it [in action](http://cl.ly/2G3D0B24201O).
 1. To end a game, `@<your_bot_name>: Quit game`
 
 ### HEROKU Getting Started
+
+#### For the lazy:
+Click this button:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+#### Manually:
 1. Install [Heroku toolbelt](https://devcenter.heroku.com/articles/getting-started-with-nodejs#set-up)
 1. Create new bot integration (as above)
 1. `heroku create`

--- a/app.json
+++ b/app.json
@@ -1,0 +1,15 @@
+{
+  "name": "Slack Poker Bot",
+  "description": "A bot that turns Slack into a legitimate Texas Hold'em client.",
+  "keywords": [
+    "slack",
+    "poker",
+    "bot"
+  ],
+  "repository": "https://github.com/CharlieHess/slack-poker-bot",
+  "env": {
+    "SLACK_POKER_BOT_TOKEN": {
+      "description": "Your Slack bot integration token (obtainable at https://my.slack.com/services/new/bot)"
+    }
+  }
+}


### PR DESCRIPTION
Because I'm fundamentally lazy, when I stumble across projects that are easy to deploy on Heroku it's awesome to have a one-click [Heroku Button](https://devcenter.heroku.com/articles/heroku-button). This automatically sets up the app based on the contents of `app.json` in the project root when clicked.

You can see how this might work by visiting [this URL](https://heroku.com/deploy?template=https://github.com/mcmillan/slack-poker-bot/tree/heroku-button) – it basically asks you for the required environment variable and then goes ahead and sets up a shiny new Heroku app for you.