### PR TITLE
Fix Big-Blind All-in Bug

### DIFF
--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -207,9 +207,9 @@ class TexasHoldem {
     this.onPlayerAction(bbPlayer, bbAction, previousActions, null, 'big blind');
 
     // So, in the preflop round we want to treat the big blind as the
-    // bettor. Because the bet was implict, that player also has an "option,"
-    // i.e., they will be the last to act.
-    bbPlayer.hasOption = true;
+    // bettor. Because the bet was implicit, that player also has an option,
+    // i.e., they will be the last to act (as long as they have chips).
+    bbPlayer.hasOption = bbPlayer.chips > 0;
   }
 
   // Private: Displays player position and who's next to act, pauses briefly,

--- a/tests/texas-holdem-spec.js
+++ b/tests/texas-holdem-spec.js
@@ -44,6 +44,36 @@ describe('TexasHoldem', function() {
     game.tableFormatter = "\n";
   });
   
+  it('should handle players who are forced all-in by posting blinds', function() {
+    game.start(playerDms, 0);
+    
+    // Sad Patrik.
+    players[3].chips = 2;
+    scheduler.advanceBy(5000);
+
+    messages.onNext({user: 4, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 5, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 1, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 2, text: "Fold"});
+    scheduler.advanceBy(10000);
+    
+    messages.onNext({user: 5, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 1, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 2, text: "Fold"});
+    scheduler.advanceBy(5000);
+    messages.onNext({user: 3, text: "Call"});
+    scheduler.advanceBy(5000);
+    
+    // Patrik either doubled up (2 * 2 = 4, minus the SB = 3), or lost it all.
+    assert(game.potManager.outcomes.length === 2);
+    assert(players[3].chips === 3 || players[3].chips === 0);
+  });
+  
   it('should award the pot to an all-in player if everyone else folds', function() {
     game.start(playerDms, 0);
     scheduler.advanceBy(5000);


### PR DESCRIPTION
This PR fixes #36. The issue was that the BB player was always given an option (i.e., they would act last), regardless of whether or not they had any chips.