### PR TITLE
Custom Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Click this button:
 Note that any player can end a game at any time with this command, so Be Honorable™.
 * To configure some bot options, `@<your-bot-name>: config <name-of-option>=<value>`. The supported options are:
 ```
-timeout: Sets the duration (in seconds) before a player times out. Set to 0 to specify no timeout.
+timeout: Sets the duration (in seconds) before a player times out. 
+Set to 0 to specify no timeout.
 ```
 So, to start a game without any player timeout, say:
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A bot that turns Slack into a legitimate Texas Hold'em client. Start a game in a
 
 See it [in action](https://www.youtube.com/watch?v=Joku-PKUObE).
 
-### Getting Started
+## Getting Started
 1. Create a new [bot integration](https://my.slack.com/services/new/bot)
 1. Follow the steps to deploy the bot to Heroku or run it locally
 1. Once the bot is running, start a game with: `@<your-bot-name>: deal`
@@ -16,7 +16,7 @@ Click this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-##### Manual Heroku
+#### Manual Heroku
 1. Install [Heroku toolbelt](https://devcenter.heroku.com/articles/getting-started-with-nodejs#set-up)
 1. Create a new bot integration (as above)
 1. `heroku create`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ See it [in action](https://www.youtube.com/watch?v=Joku-PKUObE).
 ### Getting Started
 1. Create a new [bot integration](https://my.slack.com/services/new/bot)
 1. Follow the steps to deploy the bot to Heroku or run it locally
-1. To start a game, `@<your_bot_name>: Deal`
-1. To end a game, `@<your_bot_name>: Quit game`
+1. Once the bot is running, start a game with: `@<your-bot-name>: deal`
 
 #### One-Click Heroku
 Click this button:
@@ -29,15 +28,19 @@ Click this button:
 1. `npm install`
 1. `node src/main.js`
 
-### But Can It Even?
-It can:
-- [x] Initiate a game and poll players to join
-- [x] Handle player order, blinds, and betting
-- [x] Send player's pocket cards as a DM
-- [x] Display board images
-- [x] Handle chip stacks / pot calculations
-- [x] Handle split pots / side pots
-- [x] Determine the best hand
+## Directions
+* To start a game, `@<your-bot-name>: deal`.
+* To end a game, `@<your-bot-name>: quit game`. The game will end once the current hand finishes.
+Note that any player can end a game at any time with this command, so Be Honorable™.
+* To configure some bot options, `@<your-bot-name>: config <name-of-option>=<value>`. The supported options are:
+```
+timeout: Sets the duration (in seconds) before a player times out. Set to 0 to specify no timeout.
+```
+So, to start a game without any player timeout, say:
+```
+@<your-bot-name>: config timeout=0
+@<your-bot-name>: deal
+```
 
 Check the open issues for some planned enhancements.
 
@@ -48,13 +51,13 @@ Although this client was built for managing human players in a Slack channel, it
 1. Implement `getAction`, which is called whenever it is the bot's turn
 1. Modify the `addBotPlayers` method in `src/bot.js` to add your bot to every game
 
-### Spec All The Things
-To run all of the tests, just do:
+### Test All The Things
+To run tests, simply do:
 
 1. `gulp`
 
 The tests produce legible output that matches what users in Slack would see. This is very helpful when diagnosing a logic bug:
-![](https://s3.amazonaws.com/f.cl.ly/items/2T2c472a3M390J2T2t3I/Image%202015-07-23%20at%202.26.12%20PM.png)
+![](https://s3.amazonaws.com/f.cl.ly/items/2L0Y2Y3d3g0i1x171n2V/Image%202015-09-08%20at%207.00.40%20PM.png)
 
 ### Dependencies
 * [NodeJS Slack Client](https://github.com/slackhq/node-slack-client)

--- a/ai/aggro-bot.js
+++ b/ai/aggro-bot.js
@@ -13,17 +13,16 @@ class AggroBot {
 
   // TOO STRONK
   getAction(availableActions, previousActions) {
-    let desiredAction = 'call';
+    let desiredAction = { name: 'call' };
 
     if (availableActions.indexOf('raise') > -1) {
-      desiredAction = 'raise';
+      desiredAction = { name: 'raise' };
     } else if (availableActions.indexOf('bet') > -1) {
-      desiredAction = 'bet';
+      desiredAction = { name: 'bet' };
     }
 
     let delay = 2000 + (Math.random() * 2000);
-    return rx.Observable.timer(delay).map(() => {
-      return { name: desiredAction };
-    });
+    return rx.Observable.timer(delay)
+      .flatMap(() => rx.Observable.return(desiredAction));
   }
 };

--- a/ai/weak-bot.js
+++ b/ai/weak-bot.js
@@ -16,7 +16,9 @@ class WeakBot {
     let action = availableActions.indexOf('check') > -1 ?
       { name: 'check' } :
       { name: 'call' };
+      
     let delay = 2000 + (Math.random() * 4000);
-    return rx.Observable.timer(delay).map(() => action);
+    return rx.Observable.timer(delay)
+      .flatMap(() => rx.Observable.return(action));
   }
 };

--- a/src/bot.js
+++ b/src/bot.js
@@ -86,7 +86,7 @@ class Bot {
         let channel = this.slack.getChannelGroupOrDMByID(e.channel);
         
         e.text.replace(/(\w*)=(\d*)/g, (match, key, value) => {
-          if (this.gameConfigParams.indexOf(key) > -1) {
+          if (this.gameConfigParams.indexOf(key) > -1 && value) {
             this.gameConfig[key] = value;
             channel.send(`Game ${key} has been set to ${value}.`);
           }

--- a/src/bot.js
+++ b/src/bot.js
@@ -16,6 +16,9 @@ class Bot {
   // token - An API token from the bot integration
   constructor(token) {
     this.slack = new Slack(token, true, true);
+    
+    this.gameConfig = {};
+    this.gameConfigParams = ['timeout'];
   }
 
   // Public: Brings this bot online and starts handling messages sent to it.
@@ -24,23 +27,38 @@ class Bot {
       .subscribe(() => this.onClientOpened());
 
     this.slack.login();
-    this.respondToDealMessages();
+    this.respondToMessages();
   }
 
   // Private: Listens for messages directed at this bot that contain the word
   // 'deal,' and poll players in response.
   //
   // Returns a {Disposable} that will end this subscription
-  respondToDealMessages() {
+  respondToMessages() {
     let messages = rx.Observable.fromEvent(this.slack, 'message')
       .where(e => e.type === 'message');
 
-    // Messages directed at the bot that contain the word "deal" are valid
-    let dealGameMessages = messages.where(e =>
-      MessageHelpers.containsUserMention(e.text, this.slack.self.id) &&
-        e.text.toLowerCase().match(/\bdeal\b/));
+    let atMentions = messages.where(e => 
+      MessageHelpers.containsUserMention(e.text, this.slack.self.id));
+
+    let disp = new rx.CompositeDisposable();
         
-    return dealGameMessages
+    disp.add(this.handleDealGameMessages(messages, atMentions));
+    disp.add(this.handleConfigMessages(atMentions));
+    
+    return disp;
+  }
+  
+  // Private: Looks for messages directed at the bot that contain the word
+  // "deal." When found, start polling players for a game.
+  //
+  // messages - An {Observable} representing messages posted to a channel
+  // atMentions - An {Observable} representing messages directed at the bot
+  //
+  // Returns a {Disposable} that will end this subscription
+  handleDealGameMessages(messages, atMentions) {
+    return atMentions
+      .where(e => e.text && e.text.toLowerCase().match(/\bdeal\b/))
       .map(e => this.slack.getChannelGroupOrDMByID(e.channel))
       .where(channel => {
         if (this.isPolling) {
@@ -53,6 +71,27 @@ class Bot {
       })
       .flatMap(channel => this.pollPlayersForGame(messages, channel))
       .subscribe();
+  }
+  
+  // Private: Looks for messages directed at the bot that contain the word
+  // "config" and have valid parameters. When found, set the parameter.
+  //
+  // atMentions - An {Observable} representing messages directed at the bot
+  //
+  // Returns a {Disposable} that will end this subscription
+  handleConfigMessages(atMentions) {
+    return atMentions
+      .where(e => e.text && e.text.toLowerCase().includes('config'))
+      .subscribe(e => {
+        let channel = this.slack.getChannelGroupOrDMByID(e.channel);
+        
+        e.text.replace(/(\w*)=(\d*)/g, (match, key, value) => {
+          if (this.gameConfigParams.indexOf(key) > -1) {
+            this.gameConfig[key] = value;
+            channel.send(`Game ${key} has been set to ${value}.`);
+          }
+        });
+      });
   }
   
   // Private: Polls players to join the game, and if we have enough, starts an
@@ -99,6 +138,7 @@ class Bot {
     this.isGameRunning = true;
     
     let game = new TexasHoldem(this.slack, messages, channel, players);
+    _.extend(game, this.gameConfig);
 
     // Listen for messages directed at the bot containing 'quit game.'
     messages.where(e => MessageHelpers.containsUserMention(e.text, this.slack.self.id) &&
@@ -121,11 +161,11 @@ class Bot {
   //
   // players - The players participating in the game
   addBotPlayers(players) {
-    // let bot1 = new WeakBot('Phil Hellmuth');
-    // let bot2 = new AggroBot('Phil Ivey');
-    // 
-    // players.push(bot1);
-    // players.push(bot2);
+    //let bot1 = new WeakBot('Phil Hellmuth');
+    //players.push(bot1);
+    
+    //let bot2 = new AggroBot('Phil Ivey');
+    //players.push(bot2);
   }
 
   // Private: Save which channels and groups this bot is in and log them.

--- a/src/bot.js
+++ b/src/bot.js
@@ -141,7 +141,7 @@ class Bot {
     _.extend(game, this.gameConfig);
 
     // Listen for messages directed at the bot containing 'quit game.'
-    messages.where(e => MessageHelpers.containsUserMention(e.text, this.slack.self.id) &&
+    let quitGameDisp = messages.where(e => MessageHelpers.containsUserMention(e.text, this.slack.self.id) &&
       e.text.toLowerCase().match(/quit game/))
       .take(1)
       .subscribe(e => {
@@ -154,7 +154,10 @@ class Bot {
     return SlackApiRx.openDms(this.slack, players)
       .flatMap(playerDms => rx.Observable.timer(2000)
         .flatMap(() => game.start(playerDms)))
-      .do(() => this.isGameRunning = false);
+      .do(() => {
+        quitGameDisp.dispose();
+        this.isGameRunning = false;
+      });
   }
 
   // Private: Adds AI-based players (primarily for testing purposes).

--- a/src/texas-holdem.js
+++ b/src/texas-holdem.js
@@ -236,7 +236,7 @@ class TexasHoldem {
         this.actingPlayer = player;
 
         return PlayerInteraction.getActionForPlayer(this.messages, this.channel,
-          player, previousActions, this.scheduler)
+          player, previousActions, this.scheduler, this.timeout)
           .do(action => this.onPlayerAction(player, action, previousActions, roundEnded));
         });
     });


### PR DESCRIPTION
This PR adds support for configuration messages (#8), in the format:
```
@pokerbot: config timeout=60
```
Any number of named parameters can be set in a single message, although only supported parameters will be applied to the game. Right now the only supported parameter is:
```
timeout: Configures the duration (in seconds) before a player times out. 
Set to 0 to specify no timeout.
```

### TODO:
- [x] Handle configuration messages
- [x] Wire up the `timeout` parameter
- [x] Add explanation to readme