### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.10"
+  - "iojs"
+sudo: false
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "iojs"
 sudo: false
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## Slack Poker Bot
+## Slack Poker Bot [![Build Status](https://travis-ci.org/CharlieHess/slack-poker-bot.png)](https://travis-ci.org/CharlieHess/slack-poker-bot)
+
 A bot that turns Slack into a legitimate Texas Hold'em client. Start a game in any channel or private group with 2-10 players. PokerBot will deal hands, direct message players with their hole cards, query players for their action, determine the winning hand, and handle the pot.
 
 ![](https://s3.amazonaws.com/f.cl.ly/items/3w3k222T0A1o2e0d033Q/Image%202015-09-01%20at%2011.41.33%20PM.png)
@@ -57,7 +58,7 @@ To run tests, simply do:
 
 1. `gulp`
 
-The tests produce legible output that matches what users in Slack would see. This is very helpful when diagnosing a logic bug:
+The tests produce legible output that matches what users in Slack would see. This is the same test suite that is run on each pull request. This is very helpful when diagnosing a logic bug:
 ![](https://s3.amazonaws.com/f.cl.ly/items/2L0Y2Y3d3g0i1x171n2V/Image%202015-09-08%20at%207.00.40%20PM.png)
 
 ### Dependencies

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "repository": "https://github.com/CharlieHess/slack-poker-bot",
   "scripts": {
-    "start": "node src/main.js"
+    "start": "node src/main.js",
+    "test": "gulp"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
I noticed there is a test suite available in the app, but it is not checking PRs against it when opened. This hooks into Travis CI, which is painless to set up with a GitHub login.

- [x] Repository owner (@charliehess) creates a @Travis-CI account
- [x] Enable the repository through account settings (may need to Sync list)
- [ ] Open a new PR (or commit to an existing one that contains these files) to verify results

Here's a pile of screenshots:

![screen shot 2015-09-09 at 10 25 53 am](https://cloud.githubusercontent.com/assets/80459/9766169/3a0bb5d0-56dd-11e5-961b-c072d402f2f6.png)

![screen shot 2015-09-09 at 10 26 04 am](https://cloud.githubusercontent.com/assets/80459/9766168/3a08de82-56dd-11e5-9755-a1221ff6a1aa.png)

![screen shot 2015-09-09 at 10 25 36 am](https://cloud.githubusercontent.com/assets/80459/9766167/3a08d162-56dd-11e5-93e6-e126e98c82d4.png)

![screen shot 2015-09-09 at 3 57 47 pm](https://cloud.githubusercontent.com/assets/80459/9774024/8c49bb98-570b-11e5-819b-aede0727fb1b.png)

![screen shot 2015-09-09 at 3 57 22 pm](https://cloud.githubusercontent.com/assets/80459/9774014/7df95c92-570b-11e5-8ce6-dd6b31a092e0.png)
